### PR TITLE
update card age report pipelines

### DIFF
--- a/reports/card_age.yml
+++ b/reports/card_age.yml
@@ -3,8 +3,8 @@ repository_name: cnx
 repository_owner: openstax
 zenhub_workspace_id: 5af1f4cc12da5e6d74331b60
 zenhub_pipelines:
-  - Coding/Development
-  - Code Review
+  - "WIP: 7 - Coding/Development"
+  - "WIP: 3 - Code Review"
 max_days_limit: 7
 # Template created using Jinja2
 # For teplate syntax see: https://jinja.palletsprojects.com/en/2.10.x/templates


### PR DESCRIPTION
Pipeline names have changed causing the card age report to not function as expected. This has been fixed by updating the names of the pipelines.