### PR TITLE
make PR number clickable and print message title

### DIFF
--- a/reports/list_open_prs.py
+++ b/reports/list_open_prs.py
@@ -166,7 +166,7 @@ class PullRequest:
 
     def __str__(self):
         s = """\
-{user} submitted <{url}|{repo_name}#{num}> "_{title}_", updated {age} ago:
+{user} submitted <{url}|{repo_name}#{num} _{title}_>, updated {age} ago:
 """.format(user=self.display_author(),
            repo_name=self.fields['repo_name'],
            num=self.fields['number'],

--- a/reports/list_open_prs.py
+++ b/reports/list_open_prs.py
@@ -166,7 +166,7 @@ class PullRequest:
 
     def __str__(self):
         s = """\
-{user} submitted {repo_name}#{num} "<{url}|{title}>", updated {age} ago:
+{user} submitted <{url}|{repo_name}#{num}> "_{title}_", updated {age} ago:
 """.format(user=self.display_author(),
            repo_name=self.fields['repo_name'],
            num=self.fields['number'],
@@ -239,6 +239,10 @@ for org in ORGANIZATIONS:
             pr = PullRequest.from_api(repo_name=repo['name'], **pull_request)
             if pr.should_display:
                 prs.append(pr)
+
+print("*Outstanding Pull Requests*")
+if len(prs) == 0:
+    print("No outstanding Pull Requests")
 
 prs.sort(key=lambda a: a.age)
 for pr in prs:


### PR DESCRIPTION
In the "kanban policy report" both the number and title are clickable. This changes the PR report to be the same. It also adds a title to the report so that the source code is easier to find.

**Aside:** Why do these reports run at different times of the day? Could they just run at the same time?

Also, is there a way to test this code before merging it? I'm just blindly editing the source 😊 