### PR TITLE
replace double-quotes with single quotes

### DIFF
--- a/concourse/open_prs_pipeline.yml
+++ b/concourse/open_prs_pipeline.yml
@@ -71,5 +71,5 @@ jobs:
           - -cxe
           - |-
             message=$(cat open-prs/out)
-            escaped=${message//"/'}
+            escaped=${message//\"/\'}
             curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"${escaped}\"}" "$WEBHOOK_URL"

--- a/concourse/open_prs_pipeline.yml
+++ b/concourse/open_prs_pipeline.yml
@@ -71,4 +71,5 @@ jobs:
           - -cxe
           - |-
             message=$(cat open-prs/out)
-            curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"${message}\"}" "$WEBHOOK_URL"
+            escaped=${message//"/'}
+            curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"${escaped}\"}" "$WEBHOOK_URL"


### PR DESCRIPTION
The JSON-generation does not sanitize the input so a double-quote inside a PR title caused little [Bobby Tables](https://xkcd.com/327/) to strike again!

I have no idea if this will work 🤞 